### PR TITLE
fix(Android): fix USB permission issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,32 @@ npm install react-native-tsc-printer
 Add the following to your `AndroidManifest.xml`:
 
 ```xml
+<!-- For Bluetooth connection -->
+
 <uses-permission android:name="android.permission.BLUETOOTH"/>
 <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
 <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
 <uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
+
+<!-- For USB connection -->
+
+<uses-permission android:name="android.permission.USB_PERMISSION" />
+<uses-feature android:name="android.hardware.usb.host" />
+
+<intent-filter>
+    <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+</intent-filter>
+<meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+    android:resource="@xml/device_filter" />
+```
+
+Add `android/src/main/res/xml//device_filter.xml`
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <usb-device vendor-id="1203" />
+</resources>
 ```
 
 ## iOS

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.tscprinter">
+
+    <uses-permission android:name="android.permission.USB_PERMISSION" />
+    <uses-permission android:name="android.permission.USB_DEVICE_ATTACHED" />
+    <uses-permission android:name="android.permission.USB_DEVICE_DETACHED" />
+
+    <uses-feature android:name="android.hardware.usb.host" />
+
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
           package="com.tscprinter">
 
     <uses-permission android:name="android.permission.USB_PERMISSION" />
-    <uses-permission android:name="android.permission.USB_DEVICE_ATTACHED" />
-    <uses-permission android:name="android.permission.USB_DEVICE_DETACHED" />
 
     <uses-feature android:name="android.hardware.usb.host" />
 

--- a/android/src/main/AndroidManifestNew.xml
+++ b/android/src/main/AndroidManifestNew.xml
@@ -1,2 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.USB_PERMISSION" />
+    <uses-permission android:name="android.permission.USB_DEVICE_ATTACHED" />
+    <uses-permission android:name="android.permission.USB_DEVICE_DETACHED" />
+
+    <uses-feature android:name="android.hardware.usb.host" />
 </manifest>

--- a/android/src/main/AndroidManifestNew.xml
+++ b/android/src/main/AndroidManifestNew.xml
@@ -1,7 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.USB_PERMISSION" />
-    <uses-permission android:name="android.permission.USB_DEVICE_ATTACHED" />
-    <uses-permission android:name="android.permission.USB_DEVICE_DETACHED" />
 
     <uses-feature android:name="android.hardware.usb.host" />
 </manifest>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -6,8 +6,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
     <uses-permission android:name="android.permission.USB_PERMISSION" />
-    <uses-permission android:name="android.permission.USB_DEVICE_ATTACHED" />
-    <uses-permission android:name="android.permission.USB_DEVICE_DETACHED" />
 
     <uses-feature android:name="android.hardware.usb.host" />
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,11 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
+    <uses-permission android:name="android.permission.USB_PERMISSION" />
+    <uses-permission android:name="android.permission.USB_DEVICE_ATTACHED" />
+    <uses-permission android:name="android.permission.USB_DEVICE_DETACHED" />
+
+    <uses-feature android:name="android.hardware.usb.host" />
 
     <application
       android:name=".MainApplication"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -27,7 +27,10 @@
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
+            <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
         </intent-filter>
+        <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+            android:resource="@xml/device_filter" />
       </activity>
     </application>
 </manifest>

--- a/example/android/app/src/main/res/xml/device_filter.xml
+++ b/example/android/app/src/main/res/xml/device_filter.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <usb-device vendor-id="1203" />
+</resources>


### PR DESCRIPTION
Add USB-related permissions and features to AndroidManifest files and handle USB permission requests in TscUsbModule.

* **AndroidManifest Changes:**
  - Add USB-related permissions: `android.permission.USB_PERMISSION`, `android.permission.USB_DEVICE_ATTACHED`, `android.permission.USB_DEVICE_DETACHED`.
  - Add `<uses-feature android:name="android.hardware.usb.host" />` to support USB host mode.

* **TscUsbModule Changes:**
  - Handle USB permission denial by rejecting the promise with an appropriate error message.
  - Add a check for `UsbManager.hasPermission(device)` before attempting to connect.
  - Automatically request permission if not granted, without using a separate check permission API.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mybigday/react-native-tsc-printer/pull/4?shareId=cd491733-801f-41ff-9ce5-2907d6a606c5).